### PR TITLE
Fix TypeError in AssistantMessageNormalizer when toolCalls is null

### DIFF
--- a/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
+++ b/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
@@ -41,7 +41,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
      *
      * @return array{
      *     role: 'assistant',
-     *     content: list<array{
+     *     content: string|list<array{
      *         type: 'tool_use',
      *         id: string,
      *         name: string,
@@ -53,14 +53,14 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     {
         return [
             'role' => 'assistant',
-            'content' => array_map(static function (ToolCall $toolCall) {
+            'content' => $data->hasToolCalls() ? array_map(static function (ToolCall $toolCall) {
                 return [
                     'type' => 'tool_use',
                     'id' => $toolCall->id,
                     'name' => $toolCall->name,
                     'input' => [] !== $toolCall->arguments ? $toolCall->arguments : new \stdClass(),
                 ];
-            }, $data->toolCalls),
+            }, $data->toolCalls) : $data->content,
         ];
     }
 }


### PR DESCRIPTION
## Solution
- Use `$data->hasToolCalls()` to check for tool calls existence before mapping
- Return `$data->content` when no tool calls are present
- Maintains proper return type annotation for both scenarios

## Changes
- Modified `AssistantMessageNormalizer::normalize()` method
- Added proper null safety check
- Preserves existing functionality for messages with tool calls

## Testing
- [X] Tested with AssistantMessage containing tool calls
- [X] Tested with AssistantMessage without tool calls (null toolCalls)
- [X] No breaking changes to existing API

Closes #[[302](https://github.com/symfony/ai/issues/302)]

Please submit your PR here instead:
https://github.com/symfony/ai

This repository is what we call a "subtree split": a read-only subset of that main repository.
We're looking forward to your PR there!
